### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "jest"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Berry-Pool/cardanocli-js.git"
+  }
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Berry-Pool/cardanocli-js.git"
-  }
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
- Adds a `repository` field to the `package.json`. This helps people find the github repo on places like [npm](https://www.npmjs.com/package/cardanocli-js)