### PR TITLE
Fix WhiteSpace after \ that produce a linebreak on the output command

### DIFF
--- a/index.js
+++ b/index.js
@@ -907,7 +907,7 @@ class CardanocliJs {
                 ${mintString} \
                 ${auxScript} \
                 ${metadata} \
-                ${scriptInvalid} \ 
+                ${scriptInvalid} \
                 --invalid-hereafter ${
                   options.invalidAfter
                     ? options.invalidAfter


### PR DESCRIPTION
Sorry if I annoy you with this simple fix
```
/bin/sh: line 2: --invalid-hereafter: command not found
Error: Command failed: cardano-cli transaction build-raw                 --tx-in XXXXX#0    --tx-in XXXX#0                     --tx-out "XXXX+XXXX" --tx-out "XXX+XXX+1 XX.XX" --tx-out "XX+0"                                                                                                         
                --invalid-hereafter 36977833                 --invalid-before 0                 --fee 0                 --out-file /home/catrielmuller/Dev/cardano/nftarot/cardano/tmp/tx_o4ubsu9vh.raw                 
Missing: --out-file FILE
```

