### PR TITLE
Update version due to bug in invalid-hereafter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardanocli-js",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A library binding the cardano-cli to JavaScript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version cached on npm repository does not contain the latest fix.