### PR TITLE
Fix arguments for providing datum and redeemer to plutus and minting scripts

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -222,13 +222,9 @@ exports.mintToString = (dir, minting) => {
       const script = this.jsonToPath(dir, mint.script);
       if (usedScripts.includes(script)) return "";
       usedScripts.push(script);
-      return `--minting-script-file ${script} ${
-        mint.datum
-          ? `--tx-in-script-datum-value '${JSON.stringify(mint.datum)}' `
-          : ""
-      } ${
+      return `--mint-script-file ${script} ${
         mint.redeemer
-          ? `--tx-in-script-redeemer-value '${JSON.stringify(mint.redeemer)}' `
+          ? `--mint-redeemer-value '${JSON.stringify(mint.redeemer)}' `
           : ""
       } ${
         mint.executionUnits

--- a/helper.js
+++ b/helper.js
@@ -116,11 +116,11 @@ exports.txInToString = (dir, txInList, isCollateral) => {
           : ""
       } ${
         txIn.datum
-          ? `--tx-in-script-datum-value '${JSON.stringify(txIn.datum)}' `
+          ? `--tx-in-datum-value '${JSON.stringify(txIn.datum)}' `
           : ""
       } ${
         txIn.redeemer
-          ? `--tx-in-script-redeemer-value '${JSON.stringify(txIn.redeemer)}' `
+          ? `--tx-in-redeemer-value '${JSON.stringify(txIn.redeemer)}' `
           : ""
       } ${
         txIn.executionUnits

--- a/helper.js
+++ b/helper.js
@@ -46,7 +46,7 @@ exports.certToString = (dir, certList) => {
         cert.executionUnits
           ? `--certificate-execution-units "(${
               cert.executionUnits[0] + "," + cert.executionUnits[1]
-            }})" `
+            })" `
           : ""
       }`)
   );
@@ -82,7 +82,7 @@ exports.withdrawalToString = (dir, withdrawalList) => {
         withdrawal.executionUnits
           ? `--withdrawal-execution-units "(${
               withdrawal.executionUnits[0] + "," + withdrawal.executionUnits[1]
-            }})" `
+            })" `
           : ""
       }`)
   );
@@ -126,7 +126,7 @@ exports.txInToString = (dir, txInList, isCollateral) => {
         txIn.executionUnits
           ? `--tx-in-execution-units "(${
               txIn.executionUnits[0] + "," + txIn.executionUnits[1]
-            }})" `
+            })" `
           : ""
       }`)
   );
@@ -228,9 +228,9 @@ exports.mintToString = (dir, minting) => {
           : ""
       } ${
         mint.executionUnits
-          ? `--tx-in-execution-units "(${
+          ? `--mint-execution-units "(${
               mint.executionUnits[0] + "," + mint.executionUnits[1]
-            }})" `
+            })" `
           : ""
       }`;
     })

--- a/index.js
+++ b/index.js
@@ -681,7 +681,7 @@ class CardanocliJs {
                         } \
                         --out-file ${
                           this.dir
-                        }/priv/pool/${poolName}/${poolName}.node.cert 
+                        }/priv/pool/${poolName}/${poolName}.node.cert
                     `);
     return `${this.dir}/priv/pool/${poolName}/${poolName}.node.cert`;
   }
@@ -897,6 +897,9 @@ class CardanocliJs {
     const auxScript = options.auxScript
       ? auxScriptToString(this.dir, options.auxScript)
       : "";
+
+    if (!this.protocolParametersPath) this.queryProtocolParameters();
+
     const scriptInvalid = options.scriptInvalid ? "--script-invalid" : "";
     execSync(`${this.cliPath} transaction build-raw \
                 ${txInString} \
@@ -918,6 +921,7 @@ class CardanocliJs {
                 } \
                 --fee ${options.fee ? options.fee : 0} \
                 --out-file ${this.dir}/tmp/tx_${UID}.raw \
+                --protocol-params-file ${this.protocolParametersPath} \
                 ${this.era}`);
 
     return `${this.dir}/tmp/tx_${UID}.raw`;
@@ -980,6 +984,7 @@ class CardanocliJs {
     const witnessOverride = options.witnessOverride
       ? `--witness-override ${options.witnessOverride}`
       : "";
+    if (!this.protocolParametersPath) this.queryProtocolParameters();
     execSync(`${this.cliPath} transaction build \
                 ${txInString} \
                 ${txOutString} \
@@ -1002,6 +1007,7 @@ class CardanocliJs {
                 --out-file ${this.dir}/tmp/tx_${UID}.raw \
                 ${changeAddressString} \
                 --${this.network} \
+                --protocol-params-file ${this.protocolParametersPath} \
                 ${this.era}`);
 
     return `${this.dir}/tmp/tx_${UID}.raw`;


### PR DESCRIPTION
- Change flags for providing redeemer and datum to plutus script
- Change flags for providing minting script
- Change flags for providing redeemer to minting script
- Change flags and format for tx execution units
- Remove datum for minting script as it's not used anymore
- Pass protocol params to transaction build

This should resolve issue #27 