### PR TITLE
Fix calculate min required UTxO

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -238,12 +238,12 @@ exports.mintToString = (dir, minting) => {
   return result;
 };
 
-exports.multiAssetToString = (value) => {
-  let result = "";
-  result += `"${value.lovelace}`;
-  Object.keys(value).forEach((asset) => {
+exports.multiAssetToString = (options) => {
+  let result = `"${options.address} + `;
+  result += `${options.value.lovelace}`;
+  Object.keys(options.value).forEach((asset) => {
     if (asset == "lovelace") return;
-    result += `+${value[asset]} ${asset}`;
+    result += `+${options.value[asset]} ${asset}`;
   });
   result += `"`;
   return result;

--- a/index.js
+++ b/index.js
@@ -1188,16 +1188,15 @@ class CardanocliJs {
 
   /**
    *
-   *
-   * @param {Value} value
+   * @param {options} options
    * @returns {lovelace}
    */
-  transactionCalculateMinValue(value) {
+  transactionCalculateMinValue(options) {
     this.queryProtocolParameters();
-    const multiAsset = multiAssetToString(value);
+    const multiAsset = multiAssetToString(options);
     return parseInt(
-      execSync(`${this.cliPath} transaction calculate-min-value \
-                --multi-asset ${multiAsset} \
+      execSync(`${this.cliPath} transaction calculate-min-required-utxo \
+                --tx-out ${multiAsset} \
                 --protocol-params-file ${this.protocolParametersPath}`)
         .toString()
         .replace(/\s+/g, " ")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardanocli-js",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "A library binding the cardano-cli to JavaScript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes the method for calculating the minimal required UTxO when creating multi-asset transactions.
It was using a deprecated method which does not work properly with the latest versions of `cardano-cli`.