### PR TITLE
added 1.31.0 support token name hex format

### DIFF
--- a/examples/mintMA.js
+++ b/examples/mintMA.js
@@ -38,7 +38,9 @@ const mintScript = {
   type: "sig",
 };
 const policy = cardanocliJs.transactionPolicyid(mintScript);
-const BERRYCOIN = policy + ".Berrycoin";
+const realAssetName = "Berrycoin"
+const assetName = Buffer.from(realAssetName).toString('hex')
+const BERRYCOIN = policy + "." + assetName;
 
 const tx = {
   txIn: wallet.balance().utxo,


### PR DESCRIPTION
Since cardano-node version 1.31.0 the token name should be in hex format.