### PR TITLE
Add support for script-file in transaction witness

### DIFF
--- a/index.js
+++ b/index.js
@@ -1136,6 +1136,7 @@ class CardanocliJs {
    *
    * @param {Object} options
    * @param {path} options.txBody
+   * @param {path} options.scriptFile
    * @param {path} options.signingKey
    * @returns {path}
    */
@@ -1151,11 +1152,21 @@ class CardanocliJs {
       return response.then((res) => res.text());
     }
     const UID = Math.random().toString(36).substr(2, 9);
+    if (!options.signingKey && !options.scriptFile) {
+      throw new Error("script-file or signing-key required for transaction witness command");
+    }
+    let signingParams = "";
+    if (options.scriptFile) {
+      signingParams += "--script-file ${options.scriptFile} ";
+    }
+    if (options.signingKey) {
+      signingParams += "--signing-key-file ${options.signingKey}";
+    }
     execSync(`${this.cliPath} transaction witness \
         --tx-body-file ${options.txBody} \
         --${this.network} \
-        --signing-key-file ${options.signingKey} \
-        --out-file ${this.dir}/tmp/tx_${UID}.witness`);
+        --out-file ${this.dir}/tmp/tx_${UID}.witness \
+        ${signingParams}`);
     return `${this.dir}/tmp/tx_${UID}.witness`;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardanocli-js",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A library binding the cardano-cli to JavaScript",
   "main": "index.js",
   "types": "./index.d.ts",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Berry-Pool/cardanocli-js.git"
+    "url": "https://github.com/shareslake/cardanocli-js.git"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Signed-off-by: Miguel A. Cabrera Minagorri <mcabrera@vmware.com>

Support `--script-file` when creating transaction witnesses.