### PR TITLE
Update transactionCalculateMinValue for Babbage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1208,7 +1208,8 @@ class CardanocliJs {
     return parseInt(
       execSync(`${this.cliPath} transaction calculate-min-required-utxo \
                 --tx-out ${multiAsset} \
-                --protocol-params-file ${this.protocolParametersPath}`)
+                --protocol-params-file ${this.protocolParametersPath} \
+                --babbage-era`)
         .toString()
         .replace(/\s+/g, " ")
         .split(" ")[1]


### PR DESCRIPTION
This adds in the console parameter for the Babbage era calculation of minimum UTXO required per output UTXO.