### PR TITLE
Add default to ts export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 // Typescript type definitions for cardanocli-js
 
-export class CardanocliJs {
+export default class CardanocliJs {
   constructor(options: CardanocliJs.ConstructorOptions);
 
   queryProtocolParameters(): any;


### PR DESCRIPTION
Had lot of fun trying to use cardanocli-js with typescript and node

```txt
src/app.ts:21:26 - error TS2351: This expression is not constructable.
  Type 'typeof import("/path-to-my-project/node_modules/cardanocli-js/index")' has no construct signatures.

21 const cardanocliJs = new CardanocliJs({
                            ~~~~~~~~~~~~


Found 1 error in src/app.ts:21
```

snipped of app.ts
```typescript
import CardanocliJs from "cardanocli-js";
import os from "os";
import path from "path";

const dir = path.join(os.homedir(), "CardanoProjects", "testnet");
const shelleyPath = path.join(
  os.homedir(),
  "CardanoProjects",
  "testnet",
  "config",
  "preview",
  "shelley-genesis.json"
);

const cardanocliJs = new CardanocliJs({
  network: "testnet-magic 2",
  era: "babbage",
  dir: dir,
  shelleyGenesisPath: shelleyPath,
  socketPath: path.join(
    os.homedir(),
    "CardanoProjects",
    "testnet",
    "node.socket"
  ),
});

console.log(cardanocliJs.queryTip());
```
tsconfig.json
```json
{
  "compilerOptions": {
    "target": "ES2022",                      
    "module": "ES2022",
    "moduleResolution": "node",
    "esModuleInterop": true,      
    "forceConsistentCasingInFileNames": true,
    "strict": true,                                     
    "skipLibCheck": true                        
  }
}

```

```bash
node --version
v18.12.1
```

sanitized package.json
```json
{
  "name": "test",
  "version": "1.0.0",
  "description": "",
  "main": "app.js",
  "type": "module",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "Jaco Labuschagne",
  "license": "MIT",
  "dependencies": {
    "cardanocli-js": "github:zodimo/cardanocli-js#main"
  },
  "devDependencies": {
    "@types/node": "^18.11.17",
    "typescript": "^4.9.4"
  }
}

```

To fix it the index.d.ts needed the default keyword.
