### PR TITLE
Fix double era parameter in command

### DIFF
--- a/index.js
+++ b/index.js
@@ -902,7 +902,7 @@ class CardanocliJs {
 
     const scriptInvalid = options.scriptInvalid ? "--script-invalid" : "";
     execSync(`${this.cliPath} transaction build-raw \
-                --alonzo-era \
+                ${this.era ? this.era : "--alonzo-era"} \
                 ${txInString} \
                 ${txOutString} \
                 ${txInCollateralString} \
@@ -922,8 +922,7 @@ class CardanocliJs {
                 } \
                 --fee ${options.fee ? options.fee : 0} \
                 --out-file ${this.dir}/tmp/tx_${UID}.raw \
-                --protocol-params-file ${this.protocolParametersPath} \
-                ${this.era}`);
+                --protocol-params-file ${this.protocolParametersPath}`);
 
     return `${this.dir}/tmp/tx_${UID}.raw`;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardanocli-js",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "A library binding the cardano-cli to JavaScript",
   "main": "index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
Fix command having both `--alonzo-era` and `--babbage-era` arguments when era option is specified in constructor